### PR TITLE
ASAN test workflow template

### DIFF
--- a/workflow-templates/asan.properties.json
+++ b/workflow-templates/asan.properties.json
@@ -1,0 +1,7 @@
+{
+    "name": "ASAN workflow",
+    "description": "ASAN workflow for RMF ROS packages.",
+    "categories": [
+        "C++"
+    ]
+}

--- a/workflow-templates/asan.yaml
+++ b/workflow-templates/asan.yaml
@@ -1,0 +1,22 @@
+name: asan
+
+on:
+  pull_request:
+  push:
+    branches:
+      - $default-branch
+  workflow_dispatch:
+
+jobs:
+  asan_test:
+    name: rmf asan
+    uses: open-rmf/rmf_ci_templates/.github/workflows/reusable_build.yaml@main
+    with:
+      dist-matrix: |
+          [{"ros_distribution": "humble",
+            "ubuntu_distribution": "jammy"}]
+      # NOTE: Avoid adding comments in the package lines, this can break some of the called scripts in github actions
+      packages: |
+        <package_name_1>
+        <package_name_2>
+      asan: true


### PR DESCRIPTION
Many RMF repositories would need the same workflows running to test build, asan, tsan...
This is the first try to get workflows templates working as described here: https://docs.github.com/en/actions/using-workflows/creating-starter-workflows-for-your-organization#creating-a-starter-workflow
Signed-off-by: Esteban Martinena <orensbruli@gmail.com>
