### PR TITLE
Update RMF version desc and placeholder

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -53,8 +53,8 @@ body:
     id: installation-version
     attributes:
       label: Open-RMF version or commit hash
-      description: If from binaries or docker, give the version. If from source, give the output of git rev-parse HEAD or the repos file you use.
-      placeholder: 2.3.0
+      description: If from binaries or docker, give the version of the specific RMF package or provide the RMF [release tag](https://github.com/open-rmf/rmf/tags). You may check for package versions with dpkg -l | grep rmf. If from source, give the output of git rev-parse HEAD or the repos file you use.
+      placeholder: release-jazzy-240617
     validations:
       required: true
 


### PR DESCRIPTION
This PR updates instructions for filling out RMF versions to prevent cases where community members provide a package version when reporting issues about RMF as a whole. The description clarifies that if they're using binaries/docker, they may point us to a specific RMF package version or release tag depending on what they're reporting.