### PR TITLE
Update pull_request_template.md for GenAI

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -46,4 +46,4 @@ We follow [OSRA's policy on GenAI tools](https://github.com/openrobotics/osrf-po
 - [ ] I used a GenAI tool in this PR. 
 - [ ] I did not use GenAI
 
-Details of which tool was used: 
+Generated-by: 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -39,3 +39,11 @@ If there is not a feature request issue for the feature, create one first and fi
 Provide a link to a detailed design document and discussion of that design.
 Implementations without design documentation will not be accepted until design documentation has been provided and discussed.
 Usually this is done via the feature request issue. -->
+
+### GenAI Use
+We follow OSRA's policy on GenAI tools: https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md
+
+[ ] I used a GenAI tool in this PR. 
+[ ] I did not use GenAI
+
+Details of which tool was used: 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -41,9 +41,9 @@ Implementations without design documentation will not be accepted until design d
 Usually this is done via the feature request issue. -->
 
 ### GenAI Use
-We follow OSRA's policy on GenAI tools: https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md
+We follow [OSRA's policy on GenAI tools](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md)
 
-[ ] I used a GenAI tool in this PR. 
-[ ] I did not use GenAI
+- [ ] I used a GenAI tool in this PR. 
+- [ ] I did not use GenAI
 
 Details of which tool was used: 


### PR DESCRIPTION
OSRA has a [new set](https://discourse.ros.org/t/osrf-adopts-policy-on-use-of-generative-ai-in-contributions/43685/1) of GenAI policies. We should update our pull request template to enable contributors to declare their use of genAI.
